### PR TITLE
Fixes "Uncaught TypeError: url.URL is not a constructor" error that appears when using the module for chrome extensions

### DIFF
--- a/src/httputil.ts
+++ b/src/httputil.ts
@@ -1,5 +1,5 @@
 /** Import libraries. */
-import { URL } from "url"
+const URL = (typeof window !== 'undefined' && window.URL) ? window.URL : require('url').URL
 import { makeHTTPRequest, makeHTTPSRequest } from "@dnpr/make-request"
 
 /** Import other sripts. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "esnext",
     "module": "commonjs",
     "lib": [
-      "es7"
+      "es7",
+      "dom"
     ],
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Similar to the issue found here: [TypeError: URL is not a constructor :(](https://github.com/ConsenSys/armlet/issues/105)

When using the module for Chrome Extensions, it shows this error:

![image](https://user-images.githubusercontent.com/37214468/73138913-4fae4000-4081-11ea-9cf9-45897d312622.png)


Really unsure where the "URL" constructor might have been overwritten, but the proposed solution resolves that issue. Maybe chrome's environment provides its own constructor that conflicts with the `url` module?

It passed the tests, and I was able to still use it outside of chrome extension environment.