### PR TITLE
Update collection querying to use Query2

### DIFF
--- a/src/interfaces/notion-api/v3/queryCollection.d.ts
+++ b/src/interfaces/notion-api/v3/queryCollection.d.ts
@@ -1,5 +1,5 @@
 import { Util } from "../../"
-import { Query } from "../../notion-models/collection-view/query"
+import { Query2 } from "../../notion-models/collection-view/query"
 import { Map } from "./Map"
 import {
   BlockRecord, CollectionRecord, CollectionViewRecord,
@@ -25,7 +25,7 @@ export namespace QueryCollection {
       userLocale: string
       userTimeZone: Util.TimeZone
     }
-    query: Query
+    query: Query2
   }
 
   interface Response {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -119,8 +119,11 @@ async function main() {
       },
       query: {
         aggregate: [],
-        filter: [],
-        filter_operator: "and",
+        aggregations: [],
+        filter: {
+          filters: [],
+          operator: "and"
+        },
         sort: []
       }
     })


### PR DESCRIPTION
Apparently since Notion changed their collection querying API (https://github.com/jamalex/notion-py/issues/94) the feature has been broken --however I saw that you implemented `Query2` with the new fomat.

This PR just updates the collection querying API to use Query2 instead of Query.

Thanks for this project! It's super useful.